### PR TITLE
Add bed management and complete CRUD for products/services

### DIFF
--- a/src/components/Beds.tsx
+++ b/src/components/Beds.tsx
@@ -118,7 +118,7 @@ const Beds: React.FC = () => {
       room: 'Phòng Massage',
       type: 'massage',
       status: 'maintenance',
-      equipment: ['Hệ thống massage tự động', 'Đèn âm thanh'],
+      equipment: ['H��� thống massage tự động', 'Đèn âm thanh'],
       lastCleaned: '08:00'
     },
     {
@@ -218,14 +218,27 @@ const Beds: React.FC = () => {
   };
 
   const completeBedService = (bedId: number) => {
-    setBeds(prev => prev.map(bed => 
-      bed.id === bedId ? { 
-        ...bed, 
+    setBeds(prev => prev.map(bed =>
+      bed.id === bedId ? {
+        ...bed,
         status: 'cleaning',
         currentAssignment: undefined,
         lastCleaned: getCurrentTime()
       } : bed
     ));
+  };
+
+  const addNewBed = () => {
+    const newBed: TreatmentBed = {
+      id: beds.length + 1,
+      name: `Giường ${beds.length + 1}`,
+      room: 'Phòng Massage',
+      type: 'massage',
+      status: 'available',
+      equipment: ['Hệ thống massage tự động'],
+      lastCleaned: getCurrentTime()
+    };
+    setBeds(prev => [...prev, newBed]);
   };
 
   const calculateAssignmentHeight = (startTime: string, endTime: string) => {

--- a/src/components/Beds.tsx
+++ b/src/components/Beds.tsx
@@ -236,16 +236,39 @@ const Beds: React.FC = () => {
   };
 
   const addNewBed = () => {
+    setShowAddDialog(true);
+  };
+
+  const handleAddBed = () => {
+    if (!newBedForm.name.trim()) return;
+
     const newBed: TreatmentBed = {
       id: beds.length + 1,
-      name: `Giường ${beds.length + 1}`,
-      room: 'Phòng Massage',
-      type: 'massage',
+      name: newBedForm.name,
+      room: newBedForm.room,
+      type: newBedForm.type,
       status: 'available',
-      equipment: ['Hệ thống massage tự động'],
+      equipment: newBedForm.equipment.length > 0 ? newBedForm.equipment : ['Thiết bị cơ bản'],
       lastCleaned: getCurrentTime()
     };
     setBeds(prev => [...prev, newBed]);
+    setShowAddDialog(false);
+    setNewBedForm({
+      name: '',
+      room: 'Phòng Massage',
+      type: 'massage',
+      equipment: []
+    });
+  };
+
+  const handleCancelAdd = () => {
+    setShowAddDialog(false);
+    setNewBedForm({
+      name: '',
+      room: 'Phòng Massage',
+      type: 'massage',
+      equipment: []
+    });
   };
 
   const calculateAssignmentHeight = (startTime: string, endTime: string) => {
@@ -262,7 +285,7 @@ const Beds: React.FC = () => {
 
   const showAssignmentDetails = (assignment: BedAssignment) => {
     // You can implement a modal or tooltip here
-    alert(`Khách hàng: ${assignment.customerName}\nDịch vụ: ${assignment.service}\nNh��n viên: ${assignment.staff}\nThời gian: ${assignment.startTime} - ${assignment.estimatedEndTime}`);
+    alert(`Khách hàng: ${assignment.customerName}\nDịch vụ: ${assignment.service}\nNhân viên: ${assignment.staff}\nThời gian: ${assignment.startTime} - ${assignment.estimatedEndTime}`);
   };
 
   const stats = {

--- a/src/components/Beds.tsx
+++ b/src/components/Beds.tsx
@@ -618,6 +618,98 @@ const Beds: React.FC = () => {
           </div>
         </div>
       )}
+
+      {/* Add Bed Dialog */}
+      {showAddDialog && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <div className="bg-white rounded-lg p-6 w-full max-w-md mx-4">
+            <h3 className="text-lg font-semibold text-gray-900 mb-4">Thêm giường mới</h3>
+
+            <div className="space-y-4">
+              {/* Bed Name */}
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Tên giường *
+                </label>
+                <input
+                  type="text"
+                  value={newBedForm.name}
+                  onChange={(e) => setNewBedForm(prev => ({ ...prev, name: e.target.value }))}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  placeholder="Ví dụ: Giường Massage 1"
+                />
+              </div>
+
+              {/* Room */}
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Phòng
+                </label>
+                <select
+                  value={newBedForm.room}
+                  onChange={(e) => setNewBedForm(prev => ({ ...prev, room: e.target.value }))}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                >
+                  {rooms.filter(room => room !== 'all').map(room => (
+                    <option key={room} value={room}>{room}</option>
+                  ))}
+                </select>
+              </div>
+
+              {/* Type */}
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Loại giường
+                </label>
+                <select
+                  value={newBedForm.type}
+                  onChange={(e) => setNewBedForm(prev => ({ ...prev, type: e.target.value as TreatmentBed['type'] }))}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                >
+                  <option value="massage">Massage</option>
+                  <option value="facial">Facial</option>
+                  <option value="body">Body</option>
+                  <option value="vip">VIP</option>
+                </select>
+              </div>
+
+              {/* Equipment */}
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Thiết bị (cách nhau bởi dấu phẩy)
+                </label>
+                <input
+                  type="text"
+                  value={newBedForm.equipment.join(', ')}
+                  onChange={(e) => setNewBedForm(prev => ({
+                    ...prev,
+                    equipment: e.target.value.split(',').map(item => item.trim()).filter(item => item)
+                  }))}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  placeholder="Ví dụ: Máy massage, Đèn LED, Hệ thống âm thanh"
+                />
+              </div>
+            </div>
+
+            {/* Dialog Actions */}
+            <div className="flex space-x-3 mt-6">
+              <button
+                onClick={handleCancelAdd}
+                className="flex-1 px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors"
+              >
+                Hủy
+              </button>
+              <button
+                onClick={handleAddBed}
+                disabled={!newBedForm.name.trim()}
+                className="flex-1 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:bg-gray-300 disabled:cursor-not-allowed transition-colors"
+              >
+                Thêm giường
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/Beds.tsx
+++ b/src/components/Beds.tsx
@@ -26,6 +26,13 @@ interface TreatmentBed {
 const Beds: React.FC = () => {
   const [selectedRoom, setSelectedRoom] = useState<string>('all');
   const [viewMode, setViewMode] = useState<'grid' | 'timeline'>('grid');
+  const [showAddDialog, setShowAddDialog] = useState<boolean>(false);
+  const [newBedForm, setNewBedForm] = useState({
+    name: '',
+    room: 'Phòng Massage',
+    type: 'massage' as TreatmentBed['type'],
+    equipment: [] as string[]
+  });
 
   const [beds, setBeds] = useState<TreatmentBed[]>([
     {
@@ -255,7 +262,7 @@ const Beds: React.FC = () => {
 
   const showAssignmentDetails = (assignment: BedAssignment) => {
     // You can implement a modal or tooltip here
-    alert(`Khách hàng: ${assignment.customerName}\nDịch vụ: ${assignment.service}\nNhân viên: ${assignment.staff}\nThời gian: ${assignment.startTime} - ${assignment.estimatedEndTime}`);
+    alert(`Khách hàng: ${assignment.customerName}\nDịch vụ: ${assignment.service}\nNh��n viên: ${assignment.staff}\nThời gian: ${assignment.startTime} - ${assignment.estimatedEndTime}`);
   };
 
   const stats = {

--- a/src/components/Beds.tsx
+++ b/src/components/Beds.tsx
@@ -118,7 +118,7 @@ const Beds: React.FC = () => {
       room: 'Phòng Massage',
       type: 'massage',
       status: 'maintenance',
-      equipment: ['H��� thống massage tự động', 'Đèn âm thanh'],
+      equipment: ['Hệ thống massage tự động', 'Đèn âm thanh'],
       lastCleaned: '08:00'
     },
     {
@@ -304,6 +304,13 @@ const Beds: React.FC = () => {
               Thời gian
             </button>
           </div>
+          <button
+            onClick={addNewBed}
+            className="flex items-center space-x-2 bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors duration-200"
+          >
+            <Plus className="w-4 h-4" />
+            <span>Thêm giường</span>
+          </button>
         </div>
         <div className="text-sm text-gray-600">
           Cập nhật lúc: {getCurrentTime()}

--- a/src/components/Products.tsx
+++ b/src/components/Products.tsx
@@ -244,7 +244,7 @@ const Products: React.FC = () => {
       {/* Content */}
       {activeTab === 'services' ? (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {services.map((service) => (
+          {filteredServices.map((service) => (
             <div key={service.id} className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden hover:shadow-lg transition-shadow duration-200">
               <img
                 src={service.image}

--- a/src/components/Products.tsx
+++ b/src/components/Products.tsx
@@ -28,8 +28,12 @@ interface Product {
 
 const Products: React.FC = () => {
   const [activeTab, setActiveTab] = useState<'services' | 'products'>('services');
+  const [showDialog, setShowDialog] = useState<boolean>(false);
+  const [editingItem, setEditingItem] = useState<Service | Product | null>(null);
+  const [searchTerm, setSearchTerm] = useState<string>('');
+  const [formData, setFormData] = useState<any>({});
 
-  const services = [
+  const [services, setServices] = useState<Service[]>([
     {
       id: 1,
       name: 'Chăm sóc da mặt Premium',
@@ -66,7 +70,7 @@ const Products: React.FC = () => {
       image: 'https://images.pexels.com/photos/3997376/pexels-photo-3997376.jpeg?w=300',
       status: 'active'
     },
-  ];
+  ]);
 
   const products = [
     {

--- a/src/components/Products.tsx
+++ b/src/components/Products.tsx
@@ -332,8 +332,17 @@ const Products: React.FC = () => {
                     <button className="p-2 text-gray-400 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-colors duration-200">
                       <Eye className="w-4 h-4" />
                     </button>
-                    <button className="p-2 text-gray-400 hover:text-green-600 hover:bg-green-50 rounded-lg transition-colors duration-200">
+                    <button
+                      onClick={() => openEditDialog(product)}
+                      className="p-2 text-gray-400 hover:text-green-600 hover:bg-green-50 rounded-lg transition-colors duration-200"
+                    >
                       <Edit className="w-4 h-4" />
+                    </button>
+                    <button
+                      onClick={() => handleDelete(product.id)}
+                      className="p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors duration-200"
+                    >
+                      <Trash2 className="w-4 h-4" />
                     </button>
                   </div>
                 </div>

--- a/src/components/Products.tsx
+++ b/src/components/Products.tsx
@@ -351,6 +351,160 @@ const Products: React.FC = () => {
           ))}
         </div>
       )}
+
+      {/* Add/Edit Dialog */}
+      {showDialog && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+          <div className="bg-white rounded-lg w-full max-w-2xl max-h-[90vh] overflow-y-auto">
+            <div className="flex items-center justify-between p-6 border-b">
+              <h3 className="text-lg font-semibold text-gray-900">
+                {editingItem ? 'Chỉnh sửa' : 'Thêm'} {activeTab === 'services' ? 'dịch vụ' : 'sản phẩm'}
+              </h3>
+              <button
+                onClick={closeDialog}
+                className="p-2 hover:bg-gray-100 rounded-lg transition-colors"
+              >
+                <X className="w-5 h-5 text-gray-500" />
+              </button>
+            </div>
+
+            <div className="p-6 space-y-4">
+              {/* Name */}
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Tên {activeTab === 'services' ? 'dịch vụ' : 'sản phẩm'} *
+                </label>
+                <input
+                  type="text"
+                  value={formData.name || ''}
+                  onChange={(e) => setFormData(prev => ({ ...prev, name: e.target.value }))}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  placeholder={`Nhập tên ${activeTab === 'services' ? 'dịch vụ' : 'sản phẩm'}`}
+                />
+              </div>
+
+              {/* Category */}
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Danh mục *
+                </label>
+                <input
+                  type="text"
+                  value={formData.category || ''}
+                  onChange={(e) => setFormData(prev => ({ ...prev, category: e.target.value }))}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  placeholder="Nhập danh mục"
+                />
+              </div>
+
+              {/* Price */}
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Giá *
+                </label>
+                <input
+                  type="text"
+                  value={formData.price || ''}
+                  onChange={(e) => setFormData(prev => ({ ...prev, price: e.target.value }))}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  placeholder="Ví dụ: 500,000"
+                />
+              </div>
+
+              {/* Service specific fields */}
+              {activeTab === 'services' && (
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Thời gian (phút)
+                  </label>
+                  <input
+                    type="number"
+                    value={formData.duration || ''}
+                    onChange={(e) => setFormData(prev => ({ ...prev, duration: parseInt(e.target.value) || 0 }))}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                    placeholder="Ví dụ: 90"
+                  />
+                </div>
+              )}
+
+              {/* Product specific fields */}
+              {activeTab === 'products' && (
+                <>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                      Thương hiệu
+                    </label>
+                    <input
+                      type="text"
+                      value={formData.brand || ''}
+                      onChange={(e) => setFormData(prev => ({ ...prev, brand: e.target.value }))}
+                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                      placeholder="Nhập thương hiệu"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                      Số lượng tồn kho
+                    </label>
+                    <input
+                      type="number"
+                      value={formData.stock || ''}
+                      onChange={(e) => setFormData(prev => ({ ...prev, stock: parseInt(e.target.value) || 0 }))}
+                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                      placeholder="Ví dụ: 50"
+                    />
+                  </div>
+                </>
+              )}
+
+              {/* Description */}
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Mô tả
+                </label>
+                <textarea
+                  value={formData.description || ''}
+                  onChange={(e) => setFormData(prev => ({ ...prev, description: e.target.value }))}
+                  rows={3}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  placeholder="Nhập mô tả chi tiết"
+                />
+              </div>
+
+              {/* Image URL */}
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  URL hình ảnh
+                </label>
+                <input
+                  type="url"
+                  value={formData.image || ''}
+                  onChange={(e) => setFormData(prev => ({ ...prev, image: e.target.value }))}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  placeholder="https://example.com/image.jpg"
+                />
+              </div>
+            </div>
+
+            {/* Dialog Actions */}
+            <div className="flex justify-end space-x-3 p-6 border-t bg-gray-50">
+              <button
+                onClick={closeDialog}
+                className="px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors"
+              >
+                Hủy
+              </button>
+              <button
+                onClick={handleSave}
+                disabled={!formData.name || !formData.price}
+                className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:bg-gray-300 disabled:cursor-not-allowed transition-colors"
+              >
+                {editingItem ? 'Cập nhật' : 'Thêm'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/Products.tsx
+++ b/src/components/Products.tsx
@@ -220,7 +220,10 @@ const Products: React.FC = () => {
           </button>
         </div>
         
-        <button className="flex items-center space-x-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors duration-200">
+        <button
+          onClick={openAddDialog}
+          className="flex items-center space-x-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors duration-200"
+        >
           <Plus className="w-4 h-4" />
           <span>Thêm {activeTab === 'services' ? 'dịch vụ' : 'sản phẩm'}</span>
         </button>
@@ -231,6 +234,8 @@ const Products: React.FC = () => {
         <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-5 h-5" />
         <input
           type="text"
+          value={searchTerm}
+          onChange={(e) => setSearchTerm(e.target.value)}
           placeholder={`Tìm kiếm ${activeTab === 'services' ? 'dịch vụ' : 'sản phẩm'}...`}
           className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
         />

--- a/src/components/Products.tsx
+++ b/src/components/Products.tsx
@@ -72,7 +72,7 @@ const Products: React.FC = () => {
     },
   ]);
 
-  const products = [
+  const [products, setProducts] = useState<Product[]>([
     {
       id: 1,
       name: 'Serum Vitamin C',
@@ -106,7 +106,7 @@ const Products: React.FC = () => {
       image: 'https://images.pexels.com/photos/4041388/pexels-photo-4041388.jpeg?w=300',
       status: 'low-stock'
     },
-  ];
+  ]);
 
   return (
     <div className="space-y-6">

--- a/src/components/Products.tsx
+++ b/src/components/Products.tsx
@@ -108,6 +108,91 @@ const Products: React.FC = () => {
     },
   ]);
 
+  // CRUD Functions
+  const openAddDialog = () => {
+    setEditingItem(null);
+    setFormData(activeTab === 'services' ? {
+      name: '',
+      category: '',
+      price: '',
+      duration: 0,
+      description: '',
+      image: '',
+      rating: 0,
+      reviews: 0,
+      status: 'active'
+    } : {
+      name: '',
+      category: '',
+      price: '',
+      stock: 0,
+      description: '',
+      brand: '',
+      image: '',
+      status: 'in-stock'
+    });
+    setShowDialog(true);
+  };
+
+  const openEditDialog = (item: Service | Product) => {
+    setEditingItem(item);
+    setFormData({ ...item });
+    setShowDialog(true);
+  };
+
+  const closeDialog = () => {
+    setShowDialog(false);
+    setEditingItem(null);
+    setFormData({});
+  };
+
+  const handleSave = () => {
+    if (!formData.name || !formData.price) return;
+
+    if (activeTab === 'services') {
+      if (editingItem) {
+        setServices(prev => prev.map(service =>
+          service.id === editingItem.id ? { ...formData, id: editingItem.id } : service
+        ));
+      } else {
+        const newService = { ...formData, id: Date.now() };
+        setServices(prev => [...prev, newService]);
+      }
+    } else {
+      if (editingItem) {
+        setProducts(prev => prev.map(product =>
+          product.id === editingItem.id ? { ...formData, id: editingItem.id } : product
+        ));
+      } else {
+        const newProduct = { ...formData, id: Date.now() };
+        setProducts(prev => [...prev, newProduct]);
+      }
+    }
+    closeDialog();
+  };
+
+  const handleDelete = (id: number) => {
+    if (window.confirm('Bạn có chắc chắn muốn xóa?')) {
+      if (activeTab === 'services') {
+        setServices(prev => prev.filter(service => service.id !== id));
+      } else {
+        setProducts(prev => prev.filter(product => product.id !== id));
+      }
+    }
+  };
+
+  // Filter items based on search
+  const filteredServices = services.filter(service =>
+    service.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+    service.category.toLowerCase().includes(searchTerm.toLowerCase())
+  );
+
+  const filteredProducts = products.filter(product =>
+    product.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
+    product.category.toLowerCase().includes(searchTerm.toLowerCase()) ||
+    product.brand.toLowerCase().includes(searchTerm.toLowerCase())
+  );
+
   return (
     <div className="space-y-6">
       {/* Tab Navigation */}

--- a/src/components/Products.tsx
+++ b/src/components/Products.tsx
@@ -294,7 +294,7 @@ const Products: React.FC = () => {
         </div>
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {products.map((product) => (
+          {filteredProducts.map((product) => (
             <div key={product.id} className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden hover:shadow-lg transition-shadow duration-200">
               <img
                 src={product.image}

--- a/src/components/Products.tsx
+++ b/src/components/Products.tsx
@@ -274,8 +274,17 @@ const Products: React.FC = () => {
                     <button className="p-2 text-gray-400 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-colors duration-200">
                       <Eye className="w-4 h-4" />
                     </button>
-                    <button className="p-2 text-gray-400 hover:text-green-600 hover:bg-green-50 rounded-lg transition-colors duration-200">
+                    <button
+                      onClick={() => openEditDialog(service)}
+                      className="p-2 text-gray-400 hover:text-green-600 hover:bg-green-50 rounded-lg transition-colors duration-200"
+                    >
                       <Edit className="w-4 h-4" />
+                    </button>
+                    <button
+                      onClick={() => handleDelete(service.id)}
+                      className="p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors duration-200"
+                    >
+                      <Trash2 className="w-4 h-4" />
                     </button>
                   </div>
                 </div>

--- a/src/components/Products.tsx
+++ b/src/components/Products.tsx
@@ -1,5 +1,30 @@
 import React, { useState } from 'react';
-import { Search, Plus, Edit, Eye, Package, Star } from 'lucide-react';
+import { Search, Plus, Edit, Eye, Package, Star, Trash2, X } from 'lucide-react';
+
+interface Service {
+  id: number;
+  name: string;
+  category: string;
+  price: string;
+  duration: number;
+  description: string;
+  rating: number;
+  reviews: number;
+  image: string;
+  status: string;
+}
+
+interface Product {
+  id: number;
+  name: string;
+  category: string;
+  price: string;
+  stock: number;
+  description: string;
+  brand: string;
+  image: string;
+  status: string;
+}
 
 const Products: React.FC = () => {
   const [activeTab, setActiveTab] = useState<'services' | 'products'>('services');


### PR DESCRIPTION
## Purpose

Based on the conversation history, users requested:
- Adding a "Add Bed" button to the beds section with a dialog for entering bed information
- Completing CRUD operations (add, edit, delete) for products and services management

## Code changes

### Beds Component (`src/components/Beds.tsx`)
- **Added bed creation functionality**: New state management for add bed dialog and form data
- **Implemented add bed dialog**: Modal with form fields for bed name, room, type, and equipment
- **Added "Thêm giường" button**: Blue button with plus icon in the header section
- **Form validation**: Prevents adding beds without required name field
- **State management**: Added `showAddDialog` and `newBedForm` state variables

### Products Component (`src/components/Products.tsx`)
- **Complete CRUD implementation**: Added create, read, update, delete operations for both services and products
- **Enhanced UI with action buttons**: Added edit and delete buttons alongside existing view button
- **Add/Edit dialog**: Comprehensive modal form supporting both services and products with appropriate fields
- **Search functionality**: Added search term state and filtering logic
- **Form validation**: Prevents saving without required fields (name and price)
- **TypeScript interfaces**: Added proper type definitions for Service and Product entities
- **State management**: Converted static arrays to stateful data with proper CRUD operations

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/6eb0b093f18747008bbdbe9a32c6a41f/pulse-works)

👀 [Preview Link](https://6eb0b093f18747008bbdbe9a32c6a41f-pulse-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>6eb0b093f18747008bbdbe9a32c6a41f</projectId>-->
<!--<branchName>pulse-works</branchName>-->